### PR TITLE
Fix/modern backstage

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,3 +26,5 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV PYTHON /usr/bin/python3
 
 RUN pip3 install setuptools
+
+ENV NODE_OPTIONS="${NODE_OPTIONS:-} --no-node-snapshot"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:1-18-bullseye
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-22-bullseye
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,12 @@
     // Path is relative to the devcontainer.json file.
     "dockerfile": "Dockerfile"
   },
+  "runArgs": [
+    // Disable IPv6 to prevent certain issues with Backstage 
+    // https://github.com/backstage/backstage/issues/24888
+    "--sysctl", "net.ipv6.conf.all.disable_ipv6=1",
+    "--sysctl", "net.ipv6.conf.default.disable_ipv6=1"
+  ],
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dist
 .pnp.*
 
 site/**
+
+# macOS specific filesystem cache file
+.DS_Store

--- a/docs/appendix/part-2-code.md
+++ b/docs/appendix/part-2-code.md
@@ -5,12 +5,12 @@ action will download a random cat image from the Cat API and save it to the
 workspace.
 
 ```typescript
-import { createTemplateAction } from "@backstage/plugin-scaffolder-node";
-import fs from "fs";
-import { Readable } from "stream";
-import { ReadableStream } from "stream/web";
-import { finished } from "stream/promises";
-import path from "path";
+import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+import fs from 'fs';
+import { Readable } from 'stream';
+import { ReadableStream } from 'stream/web';
+import { finished } from 'stream/promises';
+import path from 'path';
 
 // types
 export interface CatResult {
@@ -20,49 +20,38 @@ export interface CatResult {
   height: number;
 }
 
-/**
- * Creates an `acme:example` Scaffolder action.
- *
- * @remarks
- *
- * See {@link https://example.com} for more information.
- *
- * @public
- */
-export function createAcmeExampleAction() {
+export function createExampleAction() {
   // For more information on how to define custom actions, see
   //   https://backstage.io/docs/features/software-templates/writing-custom-actions
-  return createTemplateAction<{
-    myParameter: string;
-  }>({
+  return createTemplateAction({
     id: "catscanner:randomcat",
     description: "Downloads a random cat image into the workspace",
     schema: {
       input: {
-        type: "object",
-        required: [],
-        properties: {},
+        catCount: z => z.number({ description: 'The number of cat images to download' })
       },
     },
     async handler(ctx) {
       ctx.logger.info(
-        `Running example template with parameters: ${ctx.input.myParameter}`
+        `Running example template with parameters: ${ctx.input.catCount}`
       );
 
-      const catResult = await fetch(
-        "https://api.thecatapi.com/v1/images/search"
-      );
+      for (let i = 0; i < ctx.input.catCount; i++) {
+        const catResult = await fetch(
+          'https://api.thecatapi.com/v1/images/search',
+        );
 
-      const catData: Record<string, CatResult> = await catResult.json();
+        const catData: Record<string, CatResult> = await catResult.json();
 
-      const stream = fs.createWriteStream(
-        path.join(ctx.workspacePath, "catimage.jpeg")
-      );
-      const { body } = await fetch(catData[0].url);
+        const stream = fs.createWriteStream(
+          path.join(ctx.workspacePath, `catimage${i}.jpeg`),
+        );
+        const { body } = await fetch(catData[0].url);
 
-      await finished(Readable.fromWeb(body as ReadableStream).pipe(stream));
+        await finished(Readable.fromWeb(body as ReadableStream).pipe(stream));
 
-      ctx.logger.info("Cat image downloaded");
+        ctx.logger.info(`Cat image ${i} downloaded`);
+      }
     },
   });
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,12 +58,8 @@ Once it is complete, we can start the development environment by running the
 following command:
 
 ```bash
-yarn dev
+yarn start
 ```
-
-Backstage will open in the browser and or VSCode pointing to `127.0.0.1` instead
-of `localhost`. **Ensure you open the Backstage in your browser on
-`http://localhost:3000`.**
 
 ![Backstage App](./assets/getting_started_app.png)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,17 +82,6 @@ the Backstage app running, please check the following:
     and 7007. The codespace is mapping the ports to your local ports. Ensure
     you have no other processes running on those ports and both ports are mapped, you may have to manually add port 7007 in the vscode UI.
 
-??? Note "Node 20"
-
-    If you are running node 20 you will need to set the `NODE_OPTIONS=--no-node-snapshot`
-    environment variable to prevent the node process from crashing.
-
-    You can do this in a few ways, such as running
-    `NODE_OPTIONS=--no-node-snapshot yarn dev` each time you start the app, or
-    by adding it to the `dev` script in the `package.json`.
-
-    The Codespace is running on Node 18, so you should not have this issue.
-
 ## Authentication
 
 For this workshop we will need to authenticate with GitHub in order to create

--- a/docs/part-1.md
+++ b/docs/part-1.md
@@ -82,27 +82,8 @@ in the [templates section](http://localhost:3000/create?filters%5Bkind%5D=templa
 Now that we have a skeleton of our template we can enhance it to make it create
 a repo for us.
 
-There are a number of built in actions that we can take advantage of in our
-templates, but they are not all installed by default. To be able to create a
-GitHub repo, we need to install some GitHub actions into our backstage instance.
-First we need to install the plugin package using yarn:
-
-```bash
-cd packages/backend
-yarn add @backstage/plugin-scaffolder-backend-module-github
-```
-
-Then we then need to tell backstage to import this module into the backend,
-which will automatically register the actions and make them available to us. We
-need to add the following in `packages/backend/src/index.ts`
-
-```typescript
-backend.add(import("@backstage/plugin-scaffolder-backend-module-github"));
-```
-
-Now, we can then use the actions we just installed in our template and create a
-a new repo using the `publish:github` action. Add the following to your
-`template.yaml` in the `spec.steps` section:
+There are a number of built in actions that we can take advantage of in our templates.  
+To create a new repo, use the `publish:github` action by adding the following to your `template.yaml` in the `spec.steps` section:
 
 ```yaml
 - id: create-repo
@@ -132,7 +113,7 @@ After this point we do not need the newly created repository anymore, so you can
     section in Getting Started and ensure you have a valid token. You will only
     be able to make repos in an org that you have access to create public repos.
 
-!!! tip "Installed actions"
+!!! tip "Additional actions"
 
-    The above package installed a lot more actions than just the `publish:github`,
+    `publish:github` is only one of many pre-installed actions,
     [you can browse the rest of the available templates here](http://localhost:3000/create/actions).

--- a/docs/part-2.md
+++ b/docs/part-2.md
@@ -21,7 +21,7 @@ To create a new scaffolder we can leverage the backstage templates by running
 
 ```bash
 cd backstage
-yarn new --select scaffolder-module
+yarn new --select scaffolder-backend-module
 ```
 
 This will create a new scaffolder module in the `plugins` directory. You can
@@ -41,9 +41,21 @@ plugin.
 It will also be automatically imported in the `packages/backend/src/index.ts`
 file so its ready to use straight away.
 
-To confirm everything is working correctly you can now run `yarn dev` to start
+To confirm everything is working correctly you can now run `yarn start` to start
 backstage, navigate to [Installed Actions](http://localhost:3000/create/actions)
 and you should see `acme:example` in the list. (we will change this later!)
+
+??? Warning "Broken module.ts"
+
+  As of the time of writing this workshop, there's a bug in the plugin generator.
+  Please go to `plugins/scaffolder-backend-module-cat-scaffolder/src/module.ts` and update the following import:
+  ```
+  // before
+  import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node/alpha';
+
+  // after
+  import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
+  ```
 
 ## Write your action
 

--- a/docs/part-2.md
+++ b/docs/part-2.md
@@ -45,17 +45,17 @@ To confirm everything is working correctly you can now run `yarn start` to start
 backstage, navigate to [Installed Actions](http://localhost:3000/create/actions)
 and you should see `acme:example` in the list. (we will change this later!)
 
-??? Warning "Broken module.ts"
+!!! Warning "Broken module.ts"
 
-  As of the time of writing this workshop, there's a bug in the plugin generator.
-  Please go to `plugins/scaffolder-backend-module-cat-scaffolder/src/module.ts` and update the following import:
-  ```
-  // before
-  import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node/alpha';
+    As of the time of writing this workshop, there's a bug in the plugin generator.
+    Please go to `plugins/scaffolder-backend-module-cat-scaffolder/src/module.ts` and update the following import:
+    ```
+    // before
+    import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node/alpha';
 
-  // after
-  import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
-  ```
+    // after
+    import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
+    ```
 
 ## Write your action
 

--- a/docs/part-2.md
+++ b/docs/part-2.md
@@ -69,21 +69,17 @@ removing the required inputs and properties definitions. We don't need them
 
 ```typescript
 ...
-  return createTemplateAction<{
-    myParameter: string;
-  }>({
+  return createTemplateAction({
     id: "catscanner:randomcat",
     description: "Downloads a random cat image into the workspace",
     schema: {
       input: {
-        type: "object",
-        required: [],
-        properties: {},
+        catCount: z => z.number({ description: 'The number of cat images to download' })
       },
     },
     async handler(ctx) {
       ctx.logger.info(
-        `Running example template with parameters: ${ctx.input.myParameter}`
+        `Running example template with parameters: ${ctx.input.catCount}`
       );
 
       await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -93,7 +89,7 @@ removing the required inputs and properties definitions. We don't need them
 ```
 
 Now need to implement the action code in the `handler` function in
-`src/actions/example/example.ts`,. This is where we get the cat image from the
+`src/actions/example.ts`,. This is where we get the cat image from the
 API and download it to the working directory.
 
 The API that we will use is `https://api.thecatapi.com/v1/images/search`, this
@@ -119,6 +115,8 @@ You can add this action to the template by adding the following to the
 - id: download-cat-image
   name: Download Cat Image
   action: catscanner:randomcat
+  input:
+    catCount: 1
 ```
 
 You can now test your cat downloading skills in the template! You should end up

--- a/docs/part-3.md
+++ b/docs/part-3.md
@@ -16,25 +16,13 @@ allow us to create a new field type that can be used in the template.
 
 ```bash
 cd backstage
-yarn new --select plugin-react
+yarn new --select frontend-plugin
 ```
 
 We can name our plugin whatever we like, in this example we will call it
 `catscanner`.
 
-Now the plugin is created, to be able to use it, we need to add the plugin to
-the `packages/app/package.json` file. This will make the plugin available to the
-frontend (we will register out new field extension later).
-
-```json
-    "dependencies": {
-        ...
-        "@internal/backstage-plugin-catscanner-react": "link:../../plugins/catscanner-react",
-        ...
-    }
-```
-
-Now run `yarn install` to install the new plugin into the frontend app.
+You will see that the plugin is automatically added to the package.json in packages/app as a dependency.   
 
 ## Implement the field extension
 
@@ -64,12 +52,12 @@ We can create a Field Extension by using the `createScaffolderFieldExtension`
 API provided by backstage. But this comes in a few different parts, that we will
 put into different files to keep things easy.
 
-We will create a new folder in `plugins/catscanner-react/src/components` to hold
+We will create a new folder in `plugins/catscanner/src/components` to hold
 all of the files related to the extension. lets call this `RandomCatPix`.
 
 ```bash
 cd backstage/
-mkdir -p plugins/catscanner-react/src/components/RandomCatPix
+mkdir -p plugins/catscanner/src/components/RandomCatPix
 ```
 
 Inside this we need to create the primary files that will contain the react
@@ -85,7 +73,7 @@ We can create all these files by running the following commands:
 
 ```bash
 # go to the root of the react plugin
-cd backstage/plugins/catscanner-react
+cd backstage/plugins/catscanner
 touch src/components/RandomCatPix/RandomCatPixExtension.tsx \
   src/components/RandomCatPix/validation.ts \
   src/components/RandomCatPix/schema.ts \
@@ -197,17 +185,17 @@ in the `RandomCatPix` folder.
 export { RandomCatPixFieldExtension } from "./extensions";
 ```
 
-Next we do the same in the `components` folder to export the `RandomCatPix`.
+Next we do the same in the `src` folder to export the `RandomCatPix`.
 
 ```typescript
-// plugins/catscanner-react/src/components/index.ts
-export * from "./RandomCatPix";
+// plugins/catscanner-react/src/index.ts
+export * from "./components/RandomCatPix";
 ```
 
 !!! tip "Previewing your component"
 
     You can preview the extensions you write in the Backstage UI using the
-    Custom Field Explorer (accessible via the /create/edit route by default)
+    Custom Field Explorer (accessible via the [/create/edit](http://localhost:3000/create/edit) route by default)
 
     To do this you need to first register your extension using the instructions
     in the next section below.
@@ -251,7 +239,7 @@ so that the scaffolder is aware of it.
 
 ```tsx
 import { ScaffolderFieldExtensions } from "@backstage/plugin-scaffolder-react";
-import { RandomCatPixFieldExtension } from "@internal/backstage-plugin-catscanner-react";
+import { RandomCatPixFieldExtension } from "@internal/plugin-catscanner";
 
 const routes = (
   <FlatRoutes>


### PR DESCRIPTION
Updated the workshop for the current backstage version.

* Bumped node to 22
    * --no-node-snapshot is now enabled by default in the devcontainer
* Disabled IPv6
    * Not sure if this is new, but at least on my mac backstage wasn't loading until I disabled IPv6. I added a comment linking to an issue discussion on github.
* Action parameters are supposed to be passed via schema.input and use `zod` to validate input data.
    * (The previous code failed on defining too few type parameters.)
    * As experiment, I used it to allow choosing the amount of cat pictures to add to the repo
*  A bunch of plugins come preinstalled with backstage now, that includes `plugin-scaffolder-backend-module-github`
    * => Steps to install it are no longer needed (and actually result in a version dependency clash when trying to pull in the latest)
* The names of `yarn new --select` things have changed
* `yarn dev` no longer exists and has changed to `yarn start`
* frontend plugins are now automatically installed and paths have slightly changed.